### PR TITLE
Update readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is especially useful in environments where connections to arbitrary OS port
 
 ### Protocol
 
-The actual protocol is very simple. It is a multistream protocol itself, with a multicodec header. And it has a set of other protocols available to be used by the remote side. The remote side must enter:
+The actual protocol is very simple. It is a multistream protocol itself, with a multistream header. And it has a set of other protocols available to be used by the remote side. The remote side must enter:
 
 ```
 > <multistream-header-for-multistream>
@@ -60,7 +60,7 @@ na\n
 for example:
 
 ```sh
-# open connection + send multicodec headers, inc for a protocol not available
+ # open connection + send multistream headers, inc for a protocol not available
 > /multistream/1.0.0
 > /some-protocol-that-is-not-available
 
@@ -126,7 +126,7 @@ For example
 < /ipfs/bitswap/1.0.0
 
 # send selection, upgrade connection, and start protocol traffic
-> /ipfs/ipfs-dht/0.2.3
+> /ipfs/kad/0.2.3
 > <kad-dht-request-0>
 > <kad-dht-request-1>
 > ...

--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@
 
 Some protocols have sub-protocols or protocol-suites. Often, these sub protocols are optional extensions. Selecting which protocol to use -- or even knowing what is available to chose from -- is not simple.
 
-What if there was a protocol that allowed mounting or nesting other protocols, and made it easy to select which protocol to use. (This is sort of like ports, but managed at the protocol level -- not the OS -- and human readable).
+What if there was a protocol that allowed mounting or nesting other protocols, and made it easy to select which protocol to use?
+
+At the operating system level, protocol selection is usually accomplished using numbered ports, with some out-of-band agreement on the mapping of port numbers to protocols. For example, HTTP requests will use TCP port 80 unless otherwise specified.
+
+multistream-select brings this concept into the "protocol level", which gives you the flexibility to evolve a mapping of human-readable protocol names to the semantics you need, which may change over time. 
+
+This is especially useful in environments where connections to arbitrary OS ports is difficult or impossible, for example because one or more parties is behind a NAT. In such cases, a single connection with a stream multiplexer will allow you to open many independent communication channels, but you'll need some mechanism for deciding what protocol to use for each channel. If you support multiple stream multiplexers, you can even use multistream-select to decide which one to use in the first place.
 
 ### Protocol
 

--- a/README.md
+++ b/README.md
@@ -138,39 +138,6 @@ For example
 < ...
 ```
 
-### Example
-
-```
-# greeting
-> /http/multiproto.io/multistream-select/1.0
-< /http/multiproto.io/multistream-select/1.0
-
-# list available protocols
-> /http/multiproto.io/multistream-select/1.0
-> ls
-< /http/google.com/spdy/3
-< /http/w3c.org/http/1.1
-< /http/w3c.org/http/2
-< /http/bittorrent.org/1.2
-< /http/git-scm.org/1.2
-< /http/ipfs.io/exchange/bitswap/1
-< /http/ipfs.io/routing/dht/2.0.2
-< /http/ipfs.io/network/relay/0.5.2
-
-# select protocol
-> /http/multiproto.io/multistream-select/1.0
-> ls
-> /http/w3id.org/http/1.1
-> GET / HTTP/1.1
->
-< /http/w3id.org/http/1.1
-< HTTP/1.1 200 OK
-< Content-Type: text/html; charset=UTF-8
-< Content-Length: 12
-<
-< Hello World
-```
-
 ### ls example in detail
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # multistream-select
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
 [![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
 [![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)


### PR DESCRIPTION
This updates the examples to remove the ipfs peer-id component, since afaict no projects are actually using that format. I also updated the protocol strings to their current versions to more closely reflect real-world usage.

I also added a note that both sides might simultaneously send the initial multistream header, since that was also surprising to implementors after reading the docs.

The other big change is the removal of the example that lists and selects `http/multiproto.io` protocols - we could bring it back, but I think it needs at least some kind of call out that multiproto.io doesn't exist today, and that the example is there to illustrate things you could build with multistream-select. As it is, I think it reads as a description of an existing system, which is a bit confusing.

Tagging @Warchant, since this was prompted by some feedback from their work on a C++ implementation of multistream-select & libp2p. If I could send this PR back in time a few weeks, would it have helped you out?
