### PR TITLE
fix: update ls spec to match implementation(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ ls\n
 
 # response
 <varint-total-response-size-in-bytes><varint-number-of-protocols>
-<multicodec-of-available-protocol>
-<multicodec-of-available-protocol>
-<multicodec-of-available-protocol>
-...
+<varint-protocol-length><multicodec-of-available-protocol>\n
+<varint-protocol-length><multicodec-of-available-protocol>\n
+<varint-protocol-length><multicodec-of-available-protocol>\n
+# ...more protocols
+\n
 ```
 
 For example
@@ -166,14 +167,16 @@ For example
 ### ls example in detail
 
 ```
-> <varint-length>ls<newline>
-< <varint-length><varint-of-list-of-protos-size-in-bytes><varint-number-of-protocols><newline>
-< <varint-length><protocol><newline>
-# ...
-< <varint-length><protocol><newline>
+> <varint-ls-length>ls\n
+< <varint-ls-response-length><varint-number-of-protocols><varint-protocol-length><protocol>\n
+< <varint-protocol-length><protocol>\n
+# ...more protocols
+< \n
 ```
 
-Note: Each `varint-length` contains the size of the rest of the line, including the newline bytes
+`varint-ls-response-length` is the total size of the response message including _all_ the protocols and the `\n` at the end.
+
+Each protocol is an embedded multistream message (it has a length prefix and a new line suffix). So, unless there are 0 protocols the response will end with `\n\n`.
 
 ## Implementations
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ So a remote side asking for a protocol listing would look like this:
 ls\n
 
 # response
-<varint-total-response-size-in-bytes><varint-number-of-protocols>
+<varint-total-response-size-in-bytes>
 <varint-protocol-length><multicodec-of-available-protocol>\n
 <varint-protocol-length><multicodec-of-available-protocol>\n
 <varint-protocol-length><multicodec-of-available-protocol>\n
@@ -168,7 +168,7 @@ For example
 
 ```
 > <varint-ls-length>ls\n
-< <varint-ls-response-length><varint-number-of-protocols><varint-protocol-length><protocol>\n
+< <varint-ls-response-length><varint-protocol-length><protocol>\n
 < <varint-protocol-length><protocol>\n
 # ...more protocols
 < \n


### PR DESCRIPTION
In response to https://github.com/multiformats/go-multistream/issues/41 and documenting the change to fix it here https://github.com/multiformats/go-multistream/pull/43.