### PR TITLE
README.md: Mark `ls` as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ for example:
 
 #### Listing
 
-It is also possible to "list" the available protocols. A list message is simply:
+Implementations MAY support "listing" of the available protocols. A list message is simply:
 
 ```
 ls\n

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ For example
 < ...
 ```
 
+Note that `ls` support is OPTIONAL, i.e. implementations MAY support sending and/or receiving `ls`. This in turn implies that implementations MUST NOT depend on a remote node supporting `ls`.
+
 #### Implementation Recommendations
 
 **Protocol Selection**


### PR DESCRIPTION
go-multistream removed `ls` support in https://github.com/multiformats/go-multistream/pull/76. This breaks compatibility with the multistream implementation in Rust see https://github.com/libp2p/rust-libp2p/issues/2925.

I suggest doing this change, namely updating the specification after the fact, explicitly making `ls` support optional.

@Menduist is this a breaking change for nim-libp2p?

@Nashatyrev is this a breaking change for jvm-libp2p?

@kamilsa is this a breaking change for cpp-libp2p?

@btoms20 is this a breaking change for swift-libp2p?

@tomaka is this a breaking change for smoldot?

@MarcoPolo is this a breaking change for zig-libp2p?